### PR TITLE
Prevent infinite running when losing focus

### DIFF
--- a/engine/gameengine.js
+++ b/engine/gameengine.js
@@ -25,7 +25,8 @@ class GameEngine {
         this.wheel = null;
         //check when user interacts with the game for the first time. It is needed to prevent multiple attempts to play music and bypass
         //browser restrictions!
-        this.userInteracted = false; 
+        this.userInteracted = false;
+        this.inCanvas = true; //check if focused
 
         this.myReportCard = new ReportCard(this);
 
@@ -77,7 +78,7 @@ class GameEngine {
 
     start() {
 
-        this.mouse = ({x: 1000, y: 0});
+        this.mouse = ({ x: 1000, y: 0 });
 
         this.running = true;
         const gameLoop = () => {
@@ -139,6 +140,7 @@ class GameEngine {
             }
 
             this.click = getXandY(e);
+
 
             switch (e.which) {
                 case 1:
@@ -249,6 +251,27 @@ class GameEngine {
                     break;
             }
         }, false);
+
+        /**
+         * Periodically checks if the game has focus
+         * If not then the game is paused
+         */
+        function checkGameFocus() {
+            const elem = document.getElementById("gameWorld");
+
+            if (elem === document.activeElement) {
+                //console.log("focused gained")
+                that.inCanvas = true;
+            }
+            else {
+                //console.log("focused lost")
+                that.inCanvas = false;
+                that.resetControls();
+                PAUSED = true;
+            }
+        }
+        setInterval(checkGameFocus, 300);
+
     };
 
     addEntity(entity) {
@@ -315,7 +338,7 @@ class GameEngine {
         this.drawLayer(this.events);
         this.drawHealth();
         this.drawLayer(this.information);
-        
+
 
         if (PARAMS.DEBUG) {
             this.drawDebug(this.foreground1);

--- a/engine/sceneManager.js
+++ b/engine/sceneManager.js
@@ -835,6 +835,19 @@ class SceneManager {
             //draw cursor in menus when cursor is disabled
             if (PAUSED || SHOP_ACTIVE || this.transition || this.title) this.myCursor.draw(ctx);
         }
+
+        //alert message that game lost focus
+        if(!this.game.inCanvas) {
+            
+            let fontSize = 20;
+            ctx.font = fontSize + 'px "Press Start 2P"';
+            let msg = "Your cursor is not in the game screen! Please click within the game to regain control!";
+            ctx.fillStyle = "black";
+            ctx.fillText(msg, (this.game.surfaceWidth / 2) - ((fontSize) * msg.length / 2) + 2, fontSize * 4 + 2);
+            ctx.fillStyle = "red";
+            ctx.fillText(msg, (this.game.surfaceWidth / 2) - ((fontSize) * msg.length / 2), fontSize * 4);
+
+        } 
         //console.log(this.player.BB.left + " " + this.player.BB.bottom);
     };
 


### PR DESCRIPTION
-controls are reset when losing focus in the game screen
-infinite running was caused by moving and then clicking outside the game canvas. This would cause the canvas to not log anymore inputs.
-To fix periodically check if the game has focus or not