### PR TITLE
Report Card Rollback + better mercy rule

### DIFF
--- a/engine/gui/reportcard.js
+++ b/engine/gui/reportcard.js
@@ -16,8 +16,12 @@
         this.myDeathes = 0;
         this.myDiamondsEarned = 0;
         this.myDiamondsSpent = 0;
+
+        //special stuff that needs to be reset on death
         this.mySecretsFound = 0;
+        this.myLastSecretsFound = 0;
         this.myChestsOpened = 0;
+        this.myLastChestsOpened = 0;
     }
 
     drawReportCard(ctx) {
@@ -44,6 +48,25 @@
         this.myReportBox.centerBottomMulti();
         this.myReportBox.draw(ctx);
 
+    }
+
+    /**
+     * Save state of important report card info
+     * These stuff need to be reset on death since
+     * you can open chests and die, but they would still be counted
+     * again since u have to reopen them.
+     */
+    saveLastReport() {
+        this.myLastSecretsFound = this.mySecretsFound;
+        this.myLastChestsOpened = this.myChestsOpened;
+    }
+
+    /**
+     * When respawning rollback to last report card info
+     */
+    rollbackToLastReport() {
+        this.mySecretsFound = this.myLastSecretsFound;
+        this.myChestsOpened = this.myLastChestsOpened;
     }
 
     countChests() {

--- a/engine/sceneManager.js
+++ b/engine/sceneManager.js
@@ -231,19 +231,19 @@ class SceneManager {
 
         //hidden ending 2 is fully upgraded
         let endScene6;
-        if(maxed_end) {
+        if (maxed_end) {
             endScene6 =
-            [
-                "Both our power levels were over 9000...",
-                "But, I was simply built different,",
-                "and defeated him with ease.",
-            ];
+                [
+                    "Both our power levels were over 9000...",
+                    "But, I was simply built different,",
+                    "and defeated him with ease.",
+                ];
         } else {
             endScene6 =
-            [
-                "It was a tough battle. However,",
-                "I stopped him before it was too late!",
-            ];
+                [
+                    "It was a tough battle. However,",
+                    "I stopped him before it was too late!",
+                ];
         }
 
         let endScene7 =
@@ -262,16 +262,16 @@ class SceneManager {
                 "The End.",
             ];
 
-        if(maxed_end) {
+        if (maxed_end) {
             endScene9.push("[Ending #3: True Ending- Unlimited Power!]")
             endScene9.push("[Achievement: MAX Upgrades]")
-        }else if (hidden_end) {
+        } else if (hidden_end) {
             endScene9.push("[Ending #2: Cheapskate]");
             endScene9.push("[Achievement: No Purchases]");
-         } else {
-             endScene9.push("[Ending #1: Betrayal]");
-             endScene9.push("[Achievement: Default Ending]");
-         } 
+        } else {
+            endScene9.push("[Ending #1: Betrayal]");
+            endScene9.push("[Achievement: Default Ending]");
+        }
 
         let endScene10 =
             [
@@ -435,10 +435,21 @@ class SceneManager {
                 this.player.updateBB();
             }
 
-            //mercy rule: after dying the player is healed a bit
-            if (this.player.hp < (this.player.max_hp / 2)) {
-                this.player.heal((this.player.max_hp / 2) - this.player.hp);
+            //mercy rule
+            if (this.player.hp <= (this.player.max_hp / 2)) {
+                //heal to half hp if died under 3 times
+                if (this.game.myReportCard.myDeathes <= 4) {
+                    this.player.heal((this.player.max_hp / 2) - this.player.hp);
+                } else {
+                    //died a lot give them mercy and heal to full
+                    this.player.heal(this.player.max_hp);
+                }
             }
+
+            //since respawned reset the count of chests and secrets in report card to what it was at checkpoint
+            this.game.myReportCard.rollbackToLastReport();
+
+            //
         }
     }
 
@@ -511,6 +522,10 @@ class SceneManager {
             enemies: this.saveEnemies(this.game.enemies), interactables: this.saveInteractables(this.game.interactables),
             events: this.saveEvents(this.game.events), killCount: this.killCount
         };
+
+        //save found secrets and chests counter
+        this.game.myReportCard.saveLastReport();
+
     }
 
     /**
@@ -1294,12 +1309,12 @@ class SceneManager {
         let h = scene.height;
 
         //assign the background of the level
-        if(this.level.background) {
+        if (this.level.background) {
             this.game.addEntity(new Background(this.game, this.level.background.type));
         } else { //default
             this.game.addEntity(new Background(this.game, 0));
         }
-        
+
         this.makePlayer(spawnX, h - spawnY);
 
         //turn off textbox and only set it up when needed

--- a/entity/level/shop.js
+++ b/entity/level/shop.js
@@ -44,14 +44,14 @@ class Shop {
         // this.arrowPackCost = [10, 10, 10, 10, 10];
         // this.armor = [];
         // this.armorCost = [60, 90, 120, "MAX"];
-        //economy inflation
+        //economy inflation: costs 1800 diamonds for max upgrades
         this.health = [];
         this.healthCost = [25, 50, 75, 100, "MAX"];
         this.potionCost = 15;
         this.attack = [];
-        this.attackCost = [75, 125, 175, 275, "MAX"];
+        this.attackCost = [75, 125, 175, 250, "MAX"];
         this.arrow = [];
-        this.arrowCost = [50, 100, 150, 250, "MAX"];
+        this.arrowCost = [50, 100, 150, 225, "MAX"];
         this.arrowPackCost = [10, 10, 10, 10, 10];
         this.armor = [];
         this.armorCost = [75, 125, 200, "MAX"];


### PR DESCRIPTION
-added a last field to reportcard to save last chests and secrets. These are reloaded to the last field on respawn
-shop prices decreased a bit again to cost 1800 diamonds total
-better mercy rule: if player deaths is more than 3 times then they will be healed to full hp instead of only half hp.